### PR TITLE
switch from mrmr to bcrypto.

### DIFF
--- a/lib/bloom.js
+++ b/lib/bloom.js
@@ -9,7 +9,7 @@
 
 const {enforce} = require('bsert');
 const bio = require('bufio');
-const murmur3 = require('mrmr');
+const murmur3 = require('bcrypto/lib/murmur3');
 
 /*
  * Constants

--- a/lib/rolling.js
+++ b/lib/rolling.js
@@ -9,7 +9,7 @@
 
 const {enforce} = require('bsert');
 const {encoding} = require('bufio');
-const murmur3 = require('mrmr');
+const murmur3 = require('bcrypto/lib/murmur3');
 const DUMMY = Buffer.alloc(0);
 
 /**

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "bsert": "~0.0.10",
     "bufio": "~1.0.6",
-    "mrmr": "~0.1.6"
+    "bcrypto": "~4.0.1"
   },
   "devDependencies": {
     "bmocha": "^2.1.0"


### PR DESCRIPTION
This will create big dependency instead of small `mrmr`, but `bfilter` most likely wont be used without bcrypto anyway (in projects). So this is update in case we want to deprecate mrmr in favor of bcrypto.