### PR TITLE
Switch back to npm for now.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,45 +1,111 @@
 {
   "name": "bfilter",
-  "version": "2.2.0",
-  "lockfileVersion": 1,
+  "version": "2.3.0",
+  "lockfileVersion": 2,
   "requires": true,
-  "dependencies": {
-    "bcrypto": {
-      "version": "git+https://github.com/bcoin-org/bcrypto.git#34738cf15033e3bce91a4f6f41ec1ebee3c2fdc8",
-      "from": "git+https://github.com/bcoin-org/bcrypto.git#semver:~5.5.0",
-      "requires": {
+  "packages": {
+    "": {
+      "name": "bfilter",
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "bcrypto": "~5.4.0",
+        "bsert": "~0.0.10",
         "bufio": "~1.0.7",
         "loady": "~0.0.5"
       },
+      "devDependencies": {
+        "bmocha": "^2.1.5"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/bcrypto": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-5.4.0.tgz",
+      "integrity": "sha512-KDX2CR29o6ZoqpQndcCxFZAtYA1jDMnXU3jmCfzP44g++Cu7AHHtZN/JbrN/MXAg9SLvtQ8XISG+eVD9zH1+Jg==",
+      "hasInstallScript": true,
       "dependencies": {
-        "bufio": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.0.7.tgz",
-          "integrity": "sha512-bd1dDQhiC+bEbEfg56IdBv7faWa6OipMs/AFFFvtFnB3wAYjlwQpQRZ0pm6ZkgtfL0pILRXhKxOiQj6UzoMR7A=="
-        },
-        "loady": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/loady/-/loady-0.0.5.tgz",
-          "integrity": "sha512-uxKD2HIj042/HBx77NBcmEPsD+hxCgAtjEWlYNScuUjIsh/62Uyu39GOR68TBR68v+jqDL9zfftCWoUo4y03sQ=="
-        }
+        "bufio": "~1.0.7",
+        "loady": "~0.0.5"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/bmocha": {
+      "version": "2.1.5",
+      "resolved": "git+ssh://git@github.com/bcoin-org/bmocha.git#4ec0e4fd990871105fc2f0da55cf809276bc49bf",
+      "integrity": "sha512-c7LJkRqa5UIrOnsfxCrUSrQr9uU/IrMHzygTi+qwpo1Lr8KsPJW7013CyfbsUh+XtQyZ5H4J+ymr8nIT5vOw3g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "_bmocha": "bin/_bmocha",
+        "bmocha": "bin/bmocha"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/bsert": {
+      "version": "0.0.10",
+      "resolved": "git+ssh://git@github.com/chjj/bsert.git#bd09d49eab8644bca08ae8259a3d8756e7d453fc",
+      "integrity": "sha512-+MsXcRkniN3tZecfpMbOhMidIlGP6m1VzNWxOIRh9njHcXupRD8zObn6GniCMnn5KMBIw6cy/GPPgItbiWO/Yg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/bufio": {
+      "version": "1.0.7",
+      "resolved": "git+ssh://git@github.com/bcoin-org/bufio.git#91ae6c93899ff9fad7d7cee9afd2a1c4933ca984",
+      "integrity": "sha512-5NPJxx37TXfJi7EHwVBuwWjYvfKshZ/eHLtldgsUIG0gKwtDMYZv3V7WdbFxOO060iBabz551VPZe23Pdo0fQw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/loady": {
+      "version": "0.0.5",
+      "resolved": "git+ssh://git@github.com/chjj/loady.git#b94958b7ee061518f4b85ea6da380e7ee93222d5",
+      "integrity": "sha512-0tgvDe86rMAPgfAGDuBGimR6A5fa3GnBvG0A14TKl57+Qwqf5ocNb+XB0owy4R0yU1XicvSf1KejaeDOd+4+NQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    }
+  },
+  "dependencies": {
+    "bcrypto": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-5.4.0.tgz",
+      "integrity": "sha512-KDX2CR29o6ZoqpQndcCxFZAtYA1jDMnXU3jmCfzP44g++Cu7AHHtZN/JbrN/MXAg9SLvtQ8XISG+eVD9zH1+Jg==",
+      "requires": {
+        "bufio": "~1.0.7",
+        "loady": "~0.0.5"
       }
     },
     "bmocha": {
-      "version": "git+https://github.com/bcoin-org/bmocha.git#4ec0e4fd990871105fc2f0da55cf809276bc49bf",
-      "from": "git+https://github.com/bcoin-org/bmocha.git#semver:^2.1.2",
-      "dev": true
+      "version": "git+ssh://git@github.com/bcoin-org/bmocha.git#4ec0e4fd990871105fc2f0da55cf809276bc49bf",
+      "integrity": "sha512-c7LJkRqa5UIrOnsfxCrUSrQr9uU/IrMHzygTi+qwpo1Lr8KsPJW7013CyfbsUh+XtQyZ5H4J+ymr8nIT5vOw3g==",
+      "dev": true,
+      "from": "bmocha@^2.1.5"
     },
     "bsert": {
-      "version": "git+https://github.com/chjj/bsert.git#bd09d49eab8644bca08ae8259a3d8756e7d453fc",
-      "from": "git+https://github.com/chjj/bsert.git#semver:~0.0.10"
+      "version": "git+ssh://git@github.com/chjj/bsert.git#bd09d49eab8644bca08ae8259a3d8756e7d453fc",
+      "integrity": "sha512-+MsXcRkniN3tZecfpMbOhMidIlGP6m1VzNWxOIRh9njHcXupRD8zObn6GniCMnn5KMBIw6cy/GPPgItbiWO/Yg==",
+      "from": "bsert@~0.0.10"
     },
     "bufio": {
-      "version": "git+https://github.com/bcoin-org/bufio.git#91ae6c93899ff9fad7d7cee9afd2a1c4933ca984",
-      "from": "git+https://github.com/bcoin-org/bufio.git#semver:~1.0.6"
+      "version": "git+ssh://git@github.com/bcoin-org/bufio.git#91ae6c93899ff9fad7d7cee9afd2a1c4933ca984",
+      "integrity": "sha512-5NPJxx37TXfJi7EHwVBuwWjYvfKshZ/eHLtldgsUIG0gKwtDMYZv3V7WdbFxOO060iBabz551VPZe23Pdo0fQw==",
+      "from": "bufio@~1.0.7"
     },
     "loady": {
-      "version": "git+https://github.com/chjj/loady.git#b94958b7ee061518f4b85ea6da380e7ee93222d5",
-      "from": "git+https://github.com/chjj/loady.git#semver:~0.0.1"
+      "version": "git+ssh://git@github.com/chjj/loady.git#b94958b7ee061518f4b85ea6da380e7ee93222d5",
+      "integrity": "sha512-0tgvDe86rMAPgfAGDuBGimR6A5fa3GnBvG0A14TKl57+Qwqf5ocNb+XB0owy4R0yU1XicvSf1KejaeDOd+4+NQ==",
+      "from": "loady@~0.0.5"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,15 +20,15 @@
     "test": "bmocha --reporter spec test/*-test.js"
   },
   "dependencies": {
-    "bcrypto": "git+https://github.com/bcoin-org/bcrypto.git#semver:~5.5.0",
-    "bsert": "git+https://github.com/chjj/bsert.git#semver:~0.0.10",
-    "bufio": "git+https://github.com/bcoin-org/bufio.git#semver:~1.0.6",
-    "loady": "git+https://github.com/chjj/loady.git#semver:~0.0.1"
+    "bcrypto": "~5.4.0",
+    "bsert": "~0.0.10",
+    "bufio": "~1.0.7",
+    "loady": "~0.0.5"
   },
   "devDependencies": {
-    "bmocha": "git+https://github.com/bcoin-org/bmocha.git#semver:^2.1.2"
+    "bmocha": "^2.1.5"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=8.6.0"
   }
 }


### PR DESCRIPTION
Because all handshake is using `npm` until we decide to switch everything to `git` (so tools can do proper dedups and etc), I believe it makes sense to release updates to `npm` and use `npm` for now.

- Update engine to `8.6.0` - See https://github.com/bcoin-org/bcrypto/pull/64